### PR TITLE
fix: add instruction to enable CORS on Maximo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project contains activities for interacting with the **Maximo REST API** in
 
 ### Geocortex Workflow Versions
 
-The Maximo activities are designed to work with Geocortex Workflow versions `5.19` and above.
+The Maximo activities are designed to work with Geocortex Workflow versions `5.20` and above.
 
 ### Maximo Versions
 
@@ -15,9 +15,18 @@ The Maximo activities are designed to work with Maximo versions `7.6.0.2` and ab
 
 ### Cross-Origin Resource Sharing (CORS)
 
-Typically the web application running your workflow will be on a different domain than the Maximo REST API. In order for the Maximo activities to be able to communicate with the Maximo REST API your Maximo deployment must support [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS). There are several ways to enable this:
+Typically the web application running your workflow will be on a different domain than the Maximo REST API. In order for the Maximo activities to be able to communicate with the Maximo REST API your Maximo deployment must support [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS). There are multiple ways to enable this:
 
 -   Enable CORS on the Maximo web server.
+    1. Log in to Maximo as an administrator
+    1. Open the **System Properties**
+    1. Filter the **Global Properties** to those starting with `mxe.oslc.aclallow`
+    1. Set the `mxe.oslc.aclalloworigin` property to match the base URL of the web application that will use the Maximo activities. For example, one of:
+        - `https://apps.geocortex.com`
+        - `https://acme.apps.geocortex.com`
+        - `https://www.my-server.com`
+    1. Set the `mxe.oslc.aclallowheaders` property to `maxauth,x-method-override,patchtype,content-type,accept,x-public-uri,properties`
+    1. Set the `mxe.oslc.aclallowmethods` property to `POST,GET,DELETE,OPTIONS`
 -   Use a proxy that enables CORS by adding the necessary CORS headers.
     -   The following `web.config` provides an example of how to create such a proxy in **IIS** using [Application Request Routing](https://www.iis.net/downloads/microsoft/application-request-routing) and [URL Rewrite](https://www.iis.net/downloads/microsoft/url-rewrite).
         -   Note: this sample is intentionally very permissive so that it will work for most deployments. You should follow CORS best practices and restrict the allowed origins and headers to only those required for your deployment.
@@ -30,7 +39,7 @@ Typically the web application running your workflow will be on a different domai
             <customHeaders>
                 <add name="Access-Control-Allow-Origin" value="*" />
                 <add name="Access-Control-Allow-Headers" value="*" />
-                <add name="Access-Control-Allow-Methods" value="GET, HEAD, OPTIONS, POST, PUT, DELETE" />
+                <add name="Access-Control-Allow-Methods" value="GET, HEAD, OPTIONS, POST, DELETE" />
             </customHeaders>
         </httpProtocol>
         <rewrite>
@@ -60,7 +69,7 @@ To use the Maximo activities in [Geocortex Workflow Designer](https://apps.geoco
     - API: `JavaScript`
     - URL: The URL to this activity pack manifest
         - Use https://unpkg.com/@geocortex/workflow-activities-maximo/activitypack.json for the latest version
-        - Use https://unpkg.com/@geocortex/workflow-activities-maximo@0.1.4/activitypack.json for a specific version
+        - Use https://unpkg.com/@geocortex/workflow-activities-maximo@0.4.0/activitypack.json for a specific version
     - Title: Your desired title
     - Tags: Must include `geocortex-workflow-activity-pack`
 1. Reload [Geocortex Workflow Designer](https://apps.geocortex.com/workflow/designer/)

--- a/src/activities/CreateMaximoService.ts
+++ b/src/activities/CreateMaximoService.ts
@@ -31,7 +31,7 @@ export interface CreateMaximoServiceInputs {
 /** An interface that defines the outputs of the activity. */
 export interface CreateMaximoServiceOutputs {
     /**
-     * @description The Maximo service that can be supplied to other FME activities.
+     * @description The Maximo service that can be supplied to other Maximo activities.
      */
     service: MaximoService;
 }


### PR DESCRIPTION
- Add Maximo CORS configuration steps
- Bump the required Workflow version number to 5.20. 
  - Technically it works on 5.19, but there are some gotchas. 