### PR TITLE
feat: support alternate context

### DIFF
--- a/src/MaximoService.ts
+++ b/src/MaximoService.ts
@@ -1,5 +1,6 @@
 export interface MaximoService {
-    url: string;
-    authToken?: string;
     apiKey?: string;
+    authToken?: string;
+    context: string;
+    url: string;
 }

--- a/src/activities/CreateMaximoResource.ts
+++ b/src/activities/CreateMaximoResource.ts
@@ -81,7 +81,7 @@ export class CreateMaximoResource implements IActivityHandler {
             throw new Error("content is required");
         }
 
-        const url = `oslc/os/${resource}`;
+        const url = `os/${resource}`;
         const response = await post(service, url, undefined, content, {
             ...(properties ? { properties: properties } : undefined),
         });

--- a/src/activities/CreateMaximoService.ts
+++ b/src/activities/CreateMaximoService.ts
@@ -26,6 +26,11 @@ export interface CreateMaximoServiceInputs {
      * @description A Maximo API key.
      */
     apiKey: string;
+
+    /**
+     * @description The application context. The default is "oslc".
+     */
+    context: "oslc" | "api" | string;
 }
 
 /** An interface that defines the outputs of the activity. */
@@ -47,7 +52,7 @@ export class CreateMaximoService implements IActivityHandler {
     async execute(
         inputs: CreateMaximoServiceInputs
     ): Promise<CreateMaximoServiceOutputs> {
-        const { apiKey, password, url, username } = inputs;
+        const { apiKey, password, context = "oslc", url, username } = inputs;
         if (!url) {
             throw new Error("url is required");
         }
@@ -57,17 +62,19 @@ export class CreateMaximoService implements IActivityHandler {
 
         // Remove trailing slashes
         const normalizedUrl = url.replace(/\/*$/, "");
+        const normalizedContext = context.replace(/\/*$/, "");
 
         const service: MaximoService = {
-            url: normalizedUrl,
+            apiKey,
             authToken:
                 username && password
                     ? btoa(`${username}:${password}`)
                     : undefined,
-            apiKey,
+            context: normalizedContext,
+            url: normalizedUrl,
         };
 
-        await post(service, "oslc/login");
+        await post(service, "login");
 
         return {
             service,

--- a/src/activities/DeleteMaximoResource.ts
+++ b/src/activities/DeleteMaximoResource.ts
@@ -70,7 +70,7 @@ export class DeleteMaximoResource implements IActivityHandler {
             throw new Error("resource is required");
         }
 
-        const url = `oslc/os/${resource}/${getIdFromIdOrUrl(id)}`;
+        const url = `os/${resource}/${getIdFromIdOrUrl(id)}`;
         const response = await httpDelete(service, url);
 
         return {

--- a/src/activities/GetMaximoAsset.ts
+++ b/src/activities/GetMaximoAsset.ts
@@ -112,7 +112,7 @@ export class GetMaximoAsset implements IActivityHandler {
 
         const id = getIdFromIdOrUrl(assetId);
 
-        const response = await get(service, `oslc/os/mxasset/${id}`, {
+        const response = await get(service, `os/mxasset/${id}`, {
             ...(select ? { "oslc.select": select } : undefined),
         });
 

--- a/src/activities/GetMaximoAssets.ts
+++ b/src/activities/GetMaximoAssets.ts
@@ -65,7 +65,7 @@ export class GetMaximoAssets implements IActivityHandler {
             throw new Error("service is required");
         }
 
-        const response = await get(service, `oslc/os/mxasset`, {
+        const response = await get(service, `os/mxasset`, {
             ...(countOnly ? { count: 1 } : undefined),
             ...(orderBy ? { "oslc.orderBy": orderBy } : undefined),
             ...(pageSize ? { "oslc.pageSize": pageSize } : undefined),

--- a/src/activities/GetMaximoCurrentUser.ts
+++ b/src/activities/GetMaximoCurrentUser.ts
@@ -103,7 +103,7 @@ export class GetMaximoCurrentUser implements IActivityHandler {
             throw new Error("service is required");
         }
 
-        const response = await get(service, `oslc/whoami`);
+        const response = await get(service, `whoami`);
 
         return {
             result: response,

--- a/src/activities/GetMaximoResource.ts
+++ b/src/activities/GetMaximoResource.ts
@@ -83,7 +83,7 @@ export class GetMaximoResource implements IActivityHandler {
 
         const response = await get(
             service,
-            `oslc/os/${resource}/${getIdFromIdOrUrl(id)}`,
+            `os/${resource}/${getIdFromIdOrUrl(id)}`,
             {
                 ...(select ? { "oslc.select": select } : undefined),
             }

--- a/src/activities/GetMaximoResources.ts
+++ b/src/activities/GetMaximoResources.ts
@@ -102,7 +102,7 @@ export class GetMaximoResources implements IActivityHandler {
             throw new Error("resource is required");
         }
 
-        const response = await get(service, `oslc/os/${resource}`, {
+        const response = await get(service, `os/${resource}`, {
             ...(countOnly ? { count: 1 } : undefined),
             ...(orderBy ? { "oslc.orderBy": orderBy } : undefined),
             ...(pageSize ? { "oslc.pageSize": pageSize } : undefined),

--- a/src/activities/GetMaximoSystemInfo.ts
+++ b/src/activities/GetMaximoSystemInfo.ts
@@ -53,7 +53,7 @@ export class GetMaximoSystemInfo implements IActivityHandler {
             throw new Error("service is required");
         }
 
-        const response = await get(service, `oslc/systeminfo`);
+        const response = await get(service, `systeminfo`);
 
         return {
             result: response,

--- a/src/activities/SendMaximoRequest.ts
+++ b/src/activities/SendMaximoRequest.ts
@@ -95,36 +95,24 @@ export class SendMaximoRequest implements IActivityHandler {
         }
 
         if (method == "GET") {
-            const response = await get(service, `oslc/${path}`, query, headers);
+            const response = await get(service, path, query, headers);
             return {
                 result: response,
             };
         } else if (method == "POST") {
-            const response = await post(
-                service,
-                `oslc/${path}`,
-                query,
-                body,
-                headers
-            );
+            const response = await post(service, path, query, body, headers);
             return {
                 result: response,
             };
         } else if (method == "PATCH") {
-            const response = await patch(
-                service,
-                `oslc/${path}`,
-                query,
-                body,
-                headers
-            );
+            const response = await patch(service, path, query, body, headers);
             return {
                 result: response,
             };
         } else if (method == "DELETE") {
             const response = await httpDelete(
                 service,
-                `oslc/${path}`,
+                path,
                 query,
                 body,
                 headers

--- a/src/activities/UpdateMaximoAsset.ts
+++ b/src/activities/UpdateMaximoAsset.ts
@@ -105,7 +105,7 @@ export class UpdateMaximoAsset implements IActivityHandler {
 
         const response = await patch(
             service,
-            `oslc/os/mxasset/${id}`,
+            `os/mxasset/${id}`,
             undefined,
             asset,
             {

--- a/src/activities/UpdateMaximoResource.ts
+++ b/src/activities/UpdateMaximoResource.ts
@@ -89,7 +89,7 @@ export class UpdateMaximoResource implements IActivityHandler {
         }
 
         const idInPath = id ? "/" + getIdFromIdOrUrl(id) : "";
-        const url = `oslc/os/${resource}${idInPath}`;
+        const url = `os/${resource}${idInPath}`;
         const response = await post(service, url, undefined, content, {
             "x-method-override": id ? "PATCH" : "SYNC",
             patchtype: "MERGE",

--- a/src/request.ts
+++ b/src/request.ts
@@ -45,7 +45,9 @@ export async function post<T = any>(
     }
 
     const qs = objectToQueryString({ lean: 1, ...query });
-    const url = `${service.url}/${path}${qs ? "?" + qs : ""}`;
+    const url = `${service.url}/${service.context}/${path}${
+        qs ? "?" + qs : ""
+    }`;
     const response = await fetch(url, {
         method: "POST",
         headers: {


### PR DESCRIPTION
Add a `context` input to allow overriding `oslc`.
Fixes #22